### PR TITLE
Move the initialization of QueryClient outside of Providers component.

### DIFF
--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -8,9 +8,9 @@ interface LayoutProps {
   children: ReactNode
 }
 
-const Providers: FC<LayoutProps> = ({ children }) => {
-  const queryClient = new QueryClient()
+const queryClient = new QueryClient()
 
+const Providers: FC<LayoutProps> = ({ children }) => {
   return (
     <QueryClientProvider client={queryClient}>
       <SessionProvider>{children}</SessionProvider>


### PR DESCRIPTION
Hi Josh, I believe it's better to initialize query client outside of providers component. Awesome build by the way :D