### PR TITLE
Fix wrong aria labels on downvote buttons

### DIFF
--- a/src/components/CommentVotes.tsx
+++ b/src/components/CommentVotes.tsx
@@ -103,7 +103,7 @@ const CommentVotes: FC<CommentVotesProps> = ({
           'text-emerald-500': currentVote?.type === 'DOWN',
         })}
         variant='ghost'
-        aria-label='upvote'>
+        aria-label='downvote'>
         <ArrowBigDown
           className={cn('h-5 w-5 text-zinc-700', {
             'text-red-500 fill-red-500': currentVote?.type === 'DOWN',

--- a/src/components/post-vote/PostVoteClient.tsx
+++ b/src/components/post-vote/PostVoteClient.tsx
@@ -105,7 +105,7 @@ const PostVoteClient = ({
           'text-emerald-500': currentVote === 'DOWN',
         })}
         variant='ghost'
-        aria-label='upvote'>
+        aria-label='downvote'>
         <ArrowBigDown
           className={cn('h-5 w-5 text-zinc-700', {
             'text-red-500 fill-red-500': currentVote === 'DOWN',


### PR DESCRIPTION
The downvote button in `CommentVotes.tsx` and `PostVoteClient.tsx` has an aria label of "upvote" instead of "downvote"