### PR TITLE
fix: change outdated Next.js config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,9 +3,6 @@ const nextConfig = {
   images: {
     domains: ['uploadthing.com', 'lh3.googleusercontent.com'],
   },
-  experimental: {
-    appDir: true
-  }
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Remove experimental feature "appDir", as it is no longer needed when using the App Router since Next.js 13.4.

It can even cause problems with the modals unless you also add `reactStrictMode: true` to the config (see #18). Removing the experimental feature solves this issue.